### PR TITLE
feat: improve performance by using rolldown for jit

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "@quansync/fs": "^0.1.1",
     "defu": "^6.1.4",
     "jiti": "^2.4.2",
-    "quansync": "^0.2.8"
+    "quansync": "^0.2.8",
+    "rolldown": "1.0.0-beta.11"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       quansync:
         specifier: ^0.2.8
         version: 0.2.8
+      rolldown:
+        specifier: 1.0.0-beta.11
+        version: 1.0.0-beta.11
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^4.8.1
@@ -142,6 +145,15 @@ packages:
 
   '@clack/prompts@0.10.0':
     resolution: {integrity: sha512-H3rCl6CwW1NdQt9rE3n373t7o5cthPv7yUoxF2ytZvyvlJv89C5RYMJu83Hed8ODgys5vpBU0GKxIRG83jd8NQ==}
+
+  '@emnapi/core@1.4.3':
+    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
+
+  '@emnapi/runtime@1.4.3':
+    resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
+
+  '@emnapi/wasi-threads@1.0.2':
+    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
   '@es-joy/jsdoccomment@0.49.0':
     resolution: {integrity: sha512-xjZTSFgECpb9Ohuk5yMX5RhUEbfeQcuOp8IF60e+wyzWEF0M5xeSgqsfLtvPEX8BIyOX9saZqzuGPmZ8oWc+5Q==}
@@ -535,6 +547,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@napi-rs/wasm-runtime@0.2.10':
+    resolution: {integrity: sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -547,6 +562,13 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-project/runtime@0.72.2':
+    resolution: {integrity: sha512-J2lsPDen2mFs3cOA1gIBd0wsHEhum2vTnuKIRwmj3HJJcIz/XgeNdzvgSOioIXOJgURIpcDaK05jwaDG1rhDwg==}
+    engines: {node: '>=6.9.0'}
+
+  '@oxc-project/types@0.72.2':
+    resolution: {integrity: sha512-il5RF8AP85XC0CMjHF4cnVT9nT/v/ocm6qlZQpSiAR9qBbQMGkFKloBZwm7PcnOdiUX97yHgsKM7uDCCWCu3tg==}
+
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -554,6 +576,69 @@ packages:
   '@quansync/fs@0.1.1':
     resolution: {integrity: sha512-sx8J1O/+j2lqs8MvsEz6rs/6UAUpCb4fu7C6EqtMqzbS3CmqLkTDTOMK+DrWukvyUuHzl8DhMjfNJzQDTqfGJg==}
     engines: {node: '>=20.18.0'}
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.11':
+    resolution: {integrity: sha512-2yMcrMd1DHYKHMTtY9fCo4TIeDQMvSfnHovXRh/BW+1E00mVu+H84UE0VFEPNedwLKW2Jg91mjfq1s6D/wVIzw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.11':
+    resolution: {integrity: sha512-iP8GIEJ4UPlO5DD16d7OjRd3NLsuyer4nVYNnK8KqgjntxXQzDJoU8JzDIf0ujDk6KqrXgRloJWmbZziHOaCqA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.11':
+    resolution: {integrity: sha512-w9DDiyGiHZwZbO5K/wALTslP93GiLDb/YYLiu9W4fOAmbZJE86FMf48Ltjtk7OVRwSMaHmbA7nYnft5xZQwchg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.11':
+    resolution: {integrity: sha512-7Pd8I5lpELYtXWR3ByPuVa0tRkdCXOFyRHGTBLkZYjVD2XDn1d0i4EqmWZi1c29aTJFfZFOrQ9weXDyVQ+m8pQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.11':
+    resolution: {integrity: sha512-MxIa55Y7SczCv+wx/gr8IrIsJh8acXP2hfXs9GCtKdeMEk+vTo78oMNN/Wm3Ctg9TkIlkBu+JLcPPcXqt1I0Qw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.11':
+    resolution: {integrity: sha512-My8Vq1n2Z4Wc3L+3u5f5eL4SSwELfOUSl9UpPejBmDA8llfjFrQ3sm3zhcqEAzmSEzGpU+bLUfh2P/GKVnjykg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.11':
+    resolution: {integrity: sha512-3Frex4MdJcotcK8hK3SS0CVcjLbaP8s+4aSPW6LiOsIB6bGQtiZ22+VjkIJkUWYN1IvMeSXugsHLZ/GRPHlmMw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.11':
+    resolution: {integrity: sha512-C95b2ItTidz5TDHbbWQ6rNms35/tzzfQtfKAvTABuk4cvE9dMpHpZjpYDcLh8yqmzBYDU4uPn+8kqRIQqt4U+A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.11':
+    resolution: {integrity: sha512-V5MOsi6NGRb/Zfx+8ihicQoUNtPKw6Vrj9uk+7QhsX40yaEQZYdbnw7TUyErfLLMz25JOK2tvjT0V0udLKQUYQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.11':
+    resolution: {integrity: sha512-k4ZcHLJsTqWzLTFDOxn/FXtgGRlT5vuVJAIGC1ffJDf42TA02O2ZIzFQCX3FMa6/TtW/40g7P7fzH7rpw3CV6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.11':
+    resolution: {integrity: sha512-mdnWQ1jDJ83r8aEcHUgcsx5Po8uYnVkdB8DLrNUI+krx9HoPd+jNEQjuLdULH/dj81+h+Gu+UMxGHQQqhhaV7Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.11':
+    resolution: {integrity: sha512-T7eTANffCdfeRut/MBVD2hYtgaKI18qCuk4d5VyG0jcXdqKvZhlIXTJctwRHbBRANNu3LmMP17ZKRt34+jthZw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.11':
+    resolution: {integrity: sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag==}
 
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
@@ -713,6 +798,9 @@ packages:
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
+
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -895,6 +983,10 @@ packages:
 
   ansis@3.17.0:
     resolution: {integrity: sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==}
+    engines: {node: '>=14'}
+
+  ansis@4.1.0:
+    resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
     engines: {node: '>=14'}
 
   are-docs-informative@0.0.2:
@@ -2223,6 +2315,10 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-beta.11:
+    resolution: {integrity: sha512-6rtV51moX6Xl3BVLVqzUALdITog4MdVcnnf0pBW0PLJYrjDTQDWB3a4uYeFjRvQp/3ZkBAEIilz6+xvTBy23dw==}
+    hasBin: true
+
   rollup-plugin-dts@6.1.1:
     resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
     engines: {node: '>=16'}
@@ -2666,6 +2762,22 @@ snapshots:
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
+  '@emnapi/core@1.4.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.4.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@es-joy/jsdoccomment@0.49.0':
     dependencies:
       comment-parser: 1.4.1
@@ -2914,6 +3026,13 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@napi-rs/wasm-runtime@0.2.10':
+    dependencies:
+      '@emnapi/core': 1.4.3
+      '@emnapi/runtime': 1.4.3
+      '@tybys/wasm-util': 0.9.0
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2926,11 +3045,55 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.0
 
+  '@oxc-project/runtime@0.72.2': {}
+
+  '@oxc-project/types@0.72.2': {}
+
   '@pkgr/core@0.1.1': {}
 
   '@quansync/fs@0.1.1':
     dependencies:
       quansync: 0.2.8
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.11':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.10
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.11':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.11': {}
 
   '@rollup/plugin-alias@5.1.1(rollup@4.34.9)':
     optionalDependencies:
@@ -3049,6 +3212,11 @@ snapshots:
       - typescript
 
   '@trysound/sax@0.2.0': {}
+
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3293,6 +3461,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansis@3.17.0: {}
+
+  ansis@4.1.0: {}
 
   are-docs-informative@0.0.2: {}
 
@@ -4873,6 +5043,26 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.0.4: {}
+
+  rolldown@1.0.0-beta.11:
+    dependencies:
+      '@oxc-project/runtime': 0.72.2
+      '@oxc-project/types': 0.72.2
+      '@rolldown/pluginutils': 1.0.0-beta.11
+      ansis: 4.1.0
+    optionalDependencies:
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.11
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.11
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.11
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.11
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.11
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.11
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.11
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.11
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.11
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.11
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.11
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.11
 
   rollup-plugin-dts@6.1.1(rollup@4.34.9)(typescript@5.8.2):
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { quansync } from 'quansync/macro'
 import { findUp } from './fs'
 import { interopDefault } from './interop'
 import { defaultExtensions } from './types'
+import { jit } from './util/jit'
 
 export * from './types'
 
@@ -46,16 +47,15 @@ const loadConfigFile = quansync(async <T>(
         .filter(Boolean)
     },
     async: async () => {
-      const { createJiti } = await import('jiti')
-      const jiti = createJiti(import.meta.url, {
-        fsCache: false,
-        moduleCache: false,
-        interopDefault: true,
+      const module = await jit({
+        path: bundleFilepath,
       })
-      config = interopDefault(await jiti.import(bundleFilepath, { default: true }))
+      config = interopDefault(module.default)
+      /*
       dependencies = Object.values(jiti.cache)
         .map(i => i.filename)
         .filter(Boolean)
+        */
     },
   })
 

--- a/src/util/jit.ts
+++ b/src/util/jit.ts
@@ -1,0 +1,50 @@
+import { Buffer } from 'node:buffer'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { rolldown } from 'rolldown'
+
+export interface JitOptions {
+  /**
+   * The path to the file to be imported.
+   * @default process.cwd()
+   */
+  path: string
+}
+
+export async function jit(options: JitOptions): Promise<any> {
+  // Resolve the file path to an absolute path
+  const filePath = path.resolve(process.cwd(), options.path)
+  // Check if the file exists
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}`)
+  }
+
+  // Setup bundle
+  const bundle = await rolldown({
+    // Input options (https://rolldown.rs/reference/config-options#inputoptions)
+    input: filePath,
+  })
+
+  // Generate bundle in memory
+  const rolldownOutput = await bundle.generate({
+    // Output options (https://rolldown.rs/reference/config-options#outputoptions)
+    format: 'esm',
+  })
+
+  // Verify that the output is not empty
+  if (!rolldownOutput.output[0]) {
+    throw new Error('No output chunk found')
+  }
+  // Get the output chunk
+  const outputChunk = rolldownOutput.output[0]
+
+  // Convert code to base64
+  const code64 = Buffer.from(outputChunk.code).toString('base64')
+
+  // Create a new module using the base64 encoded code
+  const _module = await import(`data:text/javascript;base64,${code64}`)
+
+  // Return the module
+  return _module
+}


### PR DESCRIPTION
### Description

We were having some discussions about improving unconfig perf here : https://github.com/rolldown/tsdown/issues/241

This seems mainly related to the usage of `jiti`, which can easily burn 100-300ms. And of course, these numbers start to matter when compared to Rolldown/tsdown performances.

As such, I started some experiments by re-creating the `jiti` trick using Rolldown.

However, I'm not very familiar with the unconfig codebase so there isn't much changes.
I must say I do not quite understand what's the use case for having both a sync and async version of the functions. I mean I/O stuff should be async anyway ? 🤔
Also, there doesn't seem to be a sync version of Rolldown usage, so that might not be the solution we are looking for ?

If we really want something sync-friendly, I guess a custom solutions should be developed using oxc-transform, but that seems like a lot of work to me 😭

### Linked Issues

https://github.com/rolldown/tsdown/issues/241

### Additional context

