### PR TITLE
test: js config is cached and not updated in time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,5 +80,4 @@ dist
 # IDE
 .idea
 
-test/fixtures/js-cache/test.config.js
-test/fixtures/js-cache/test.config.ts
+test/fixtures/cache/

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,7 +1,6 @@
 import type { LoadConfigOptions } from '../src'
 import { resolve } from 'node:path'
-import { writeFile } from '@quansync/fs'
-import { afterEach, beforeEach, expect, it } from 'vitest'
+import { expect, it } from 'vitest'
 import { loadConfig, loadConfigSync } from '../src'
 import { sourcePackageJsonFields, sourcePluginFactory } from '../src/presets'
 
@@ -87,17 +86,23 @@ it('array', async () => {
     .toMatchSnapshot()
 })
 
-// Test JS config loading with different config files
-it('js-config', async () => {
-  const cwd = resolve(fixtureDir, 'js-cache')
-  const configPath = resolve(cwd, 'test.config.js')
+// Test config loading with different config files
+it.for([
+  { ext: 'js' },
+  { ext: 'ts' },
+])('$ext-config', async ({ ext }) => {
+  const cwd = resolve(fixtureDir, 'cache')
+  const configFileName = `test-${ext}.config`
+  const configPath = resolve(cwd, `${configFileName}.${ext}`)
+  const { writeFile, mkdir } = await import('@quansync/fs')
 
+  await mkdir(cwd, { recursive: true })
   await writeFile(configPath, `export default {
   value: 'one',
 }`, 'utf8')
 
   const result1 = await loadConfig({
-    sources: [{ files: 'test.config' }],
+    sources: [{ files: configFileName }],
     cwd,
   })
 
@@ -111,40 +116,7 @@ it('js-config', async () => {
 }`, 'utf8')
 
   const result2 = await loadConfig({
-    sources: [{ files: 'test.config' }],
-    cwd,
-  })
-
-  expect(result2.config).toEqual({
-    value: 'two',
-  })
-})
-
-// Test TS config loading with different config files
-it('ts-config', async () => {
-  const cwd = resolve(fixtureDir, 'js-cache')
-  const configPath = resolve(cwd, 'test.config.ts')
-
-  await writeFile(configPath, `export default {
-  value: 'one',
-}`, 'utf8')
-
-  const result1 = await loadConfig({
-    sources: [{ files: 'test.config' }],
-    cwd,
-  })
-
-  expect(result1.config).toEqual({
-    value: 'one',
-  })
-
-  // Mock hot reload by rewriting the config file
-  await writeFile(configPath, `export default {
-  value: 'two',
-}`, 'utf8')
-
-  const result2 = await loadConfig({
-    sources: [{ files: 'test.config' }],
+    sources: [{ files: configFileName }],
     cwd,
   })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This is a test PR that uses Jiti to load different JS/TS configuration files, resulting in varying outcomes.

The TS configuration file is able to return the latest updated version from Jiti in a timely manner, but the JS file is not up-to-date with the latest configuration.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
