### PR TITLE
fix: stack overflow when config have both default and named exports

### DIFF
--- a/packages/unconfig/src/interop.ts
+++ b/packages/unconfig/src/interop.ts
@@ -9,15 +9,16 @@ export function interopDefault<T>(mod: T & { default?: T }): T {
 
   for (const key in mod) {
     try {
-      if (!(key in defaultValue)) {
-        Object.defineProperty(defaultValue, key, {
-          enumerable: key !== 'default',
-          configurable: key !== 'default',
-          get() {
-            return (mod as any)[key]
-          },
-        })
-      }
+      if (key in defaultValue || key === 'default' || (mod as any)[key] === defaultValue)
+        continue
+
+      Object.defineProperty(defaultValue, key, {
+        configurable: true,
+        enumerable: true,
+        get() {
+          return (mod as any)[key]
+        },
+      })
     }
     catch {}
   }

--- a/packages/unconfig/test/run.test.ts
+++ b/packages/unconfig/test/run.test.ts
@@ -124,6 +124,94 @@ it.each([
   expect(result2.config).toEqual({
     value: 'two',
   })
+
+  // Test config with default and named exports simultaneously
+  await writeFile(configPath, `export const config = {
+  value: 'three',
+}
+export default config`, 'utf8')
+
+  const result3 = await loadConfig({
+    sources: [{ files: configFileName }],
+    cwd,
+  })
+
+  expect(result3.config).toEqual({
+    value: 'three',
+  })
+
+  // Test config with several named exports only
+  await writeFile(configPath, `export const config1 = {
+  value1: 'config-1',
+}
+export const config2= {
+  value2: 'config-2',
+}`, 'utf8')
+
+  const result4 = await loadConfig({
+    sources: [{ files: configFileName }],
+    cwd,
+  })
+
+  expect(result4.config).toEqual({
+    config1: {
+      value1: 'config-1',
+    },
+    config2: {
+      value2: 'config-2',
+    },
+  })
+
+  // Test config with default and several named exports simultaneously
+  await writeFile(configPath, `export const config1 = {
+  value1: 'config-1',
+}
+export const config2= {
+  value2: 'config-2',
+}
+export const config3= {
+  value3: 'config-3',
+}
+export default config3`, 'utf8')
+
+  const result5 = await loadConfig({
+    sources: [{ files: configFileName }],
+    cwd,
+  })
+
+  expect(result5.config).toEqual({
+    config1: {
+      value1: 'config-1',
+    },
+    config2: {
+      value2: 'config-2',
+    },
+    value3: 'config-3',
+  })
+
+  // Test config when default export property and named export itself have similar names
+  await writeFile(configPath, `export const config1 = {
+  value1: 'config-1',
+}
+export const config2= {
+  value2: 'config-2',
+}
+export const config3= {
+  config1: 'config-3',
+}
+export default config3`, 'utf8')
+
+  const result6 = await loadConfig({
+    sources: [{ files: configFileName }],
+    cwd,
+  })
+
+  expect(result6.config).toEqual({
+    config1: 'config-3',
+    config2: {
+      value2: 'config-2',
+    },
+  })
 })
 
 it('custom parser', async () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

#### 🧩 Backstory

After the 7.4.0 update, a `Maximum call stack size exceeded` error started to occur when using `taze`, that started throwing errors with configurations that export both default and named exports simultaneously.

#### 🐛 Issue

After some debugging, I traced the issue back to [this change](https://github.com/antfu-collective/unconfig/commit/cc90b5fb238bd960fc98bfe9d9b5c1c428f8f497#diff-007421f50e45dcf2caaded94bb53fcd9a9ea27955f497f1612f96ef01d05b1e3L58-R85), which introduced the faulty behavior. As I understand, [`interopDefault`](https://github.com/antfu-collective/unconfig/blob/main/packages/unconfig/src/interop.ts) function tries to create a getter for the self-referential `default` key and/or for the module property which already is the default object. This results in defining a self-referential getter (`defaultValue.default` → `mod.default` → `defaultValue`), which leads to infinite recursion when Node attempts to inspect or log the object, ultimately triggering the stack overflow.

#### ✔️ Fix

This PR prevents processing the `default` key or the module property which already is the default object when defining forwarded getters. By skipping these, we avoid creating a self-referential properties and eliminate the infinite recursion.

#### 🧪 Tests

All existing tests have passed.
Also, I’ve added several new tests covering the main scenarios that previously triggered the recursion.

#### 🧾 Reproduction

[`unconfig-repro`](https://github.com/astrochemx/unconfig-repro)

### Additional context

I’m not deeply familiar with the internal design of `unconfig` and its ecosystem, so the approach may not be ideal.
Feedback and further refinements are very welcome.